### PR TITLE
Support browsers without Object.assign

### DIFF
--- a/lib/fixes/flexbox_IE2012.js
+++ b/lib/fixes/flexbox_IE2012.js
@@ -3,6 +3,9 @@
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 exports['default'] = flexbox_IE2012;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
@@ -37,7 +40,7 @@ function flexbox_IE2012(prop, value) {
   var base = {};
   base[prop] = value;
 
-  var propertyResults = Object.assign(base, renameProperty(prop, value));
+  var propertyResults = _extends({}, base, renameProperty(prop, value));
 
   var result = Object.keys(propertyResults).reduce(function (result, prop) {
     if (Object.keys(FLEX_PROPERTIES).indexOf(prop) > -1) {
@@ -49,7 +52,7 @@ function flexbox_IE2012(prop, value) {
 
     var withRenamedValues = renameValue(prop, propertyResults[prop]);
 
-    return Object.assign(result, base, withRenamedValues);
+    return _extends({}, result, base, withRenamedValues);
   }, {});
 
   return result;

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -3,6 +3,9 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 exports["default"] = merge;
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } }
@@ -37,7 +40,7 @@ function merge(a, b) {
     }
 
     return result;
-  }, Object.assign({}, a, b));
+  }, _extends({}, a, b));
 }
 
 module.exports = exports["default"];

--- a/src/fixes/flexbox_IE2012.js
+++ b/src/fixes/flexbox_IE2012.js
@@ -46,7 +46,7 @@ export default function flexbox_IE2012 (prop, value) {
   const base = {};
   base[prop] = value;
 
-  const propertyResults = Object.assign(base, renameProperty(prop, value));
+  const propertyResults = {...base, ...renameProperty(prop, value)};
 
   const result = Object.keys(propertyResults).reduce((result, prop) => {
     if (Object.keys(FLEX_PROPERTIES).indexOf(prop) > -1) {
@@ -55,10 +55,10 @@ export default function flexbox_IE2012 (prop, value) {
 
     const base = {};
     base[prop] = propertyResults[prop];
-    
+
     const withRenamedValues = renameValue(prop, propertyResults[prop]);
 
-    return Object.assign(result, base, withRenamedValues);
+    return {...result, ...base, ...withRenamedValues};
   }, {});
 
   return result;

--- a/src/merge.js
+++ b/src/merge.js
@@ -22,5 +22,5 @@ export default function merge (a, b) {
     }
 
     return result;
-  }, Object.assign({},a,b));
+  }, {...a, ...b});
 }


### PR DESCRIPTION
Noticed that prefix-lite wasn't working in IE and replaced Object.assign usage with ES7 object spread.
